### PR TITLE
[#46] [#53] Add support for more locales, fix hard-coded title of webview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Support of locales ca, es, nl, pl, ro, ru, sk (Orange-OpenSource/accessibility-statement-lib-ios#46)
 - Integration OUDS library (Orange-OpenSource/accessibility-statement-lib-ios#38)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update README with Swift Package Index badge (Orange-OpenSource/accessibility-statement-lib-ios#47)
 - Generation of documentation and upload for GitHub Pages (Orange-OpenSource/accessibility-statement-lib-ios#50)
 
+### Fixed
+
+- Hard-coded "Details" word instead of localized resource in webview title (Orange-OpenSource/accessibility-statement-lib-ios#53)
+
 ## [2.0.0](https://github.com/Orange-OpenSource/accessibility-statement-lib-ios/compare/1.3.0...2.0.0) - 2026-01-22
 
 ### Added

--- a/Sources/DeclarationAccessibility/Ressources/ca.lproj/Localizable.strings
+++ b/Sources/DeclarationAccessibility/Ressources/ca.lproj/Localizable.strings
@@ -1,0 +1,16 @@
+// Software Name: accessibility-statement-lib-ios
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: Apache-2.0
+//
+// This software is distributed under the Apache 2.0 license,
+// the text of which is available at https://opensource.org/license/apache-2-0
+// or see the "LICENSE" file for more details.
+
+"declaration_title" = "Informació";
+"average_title_label" = "compleix amb @%";
+"result_declaration_subtitle" = "Aquesta aplicació compleix amb @% els criteris WCAG";
+"date_title" = "Data de l'auditoria";
+"identity_title" = "Identitat del declarant";
+"referential_title" = "Estàndard aplicat";
+"technology_title" = "Característiques tècniques";
+"detail_button" = "Mostra els detalls";

--- a/Sources/DeclarationAccessibility/Ressources/es.lproj/Localizable.strings
+++ b/Sources/DeclarationAccessibility/Ressources/es.lproj/Localizable.strings
@@ -1,0 +1,16 @@
+// Software Name: accessibility-statement-lib-ios
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: Apache-2.0
+//
+// This software is distributed under the Apache 2.0 license,
+// the text of which is available at https://opensource.org/license/apache-2-0
+// or see the "LICENSE" file for more details.
+
+"declaration_title" = "Información";
+"average_title_label" = "cumple con @%";
+"result_declaration_subtitle" = "Esta aplicación cumple con @% los criterios WCAG";
+"date_title" = "Fecha de la auditoría";
+"identity_title" = "Identidad del declarante";
+"referential_title" = "Norma aplicada";
+"technology_title" = "Especificaciones técnicas";
+"detail_button" = "Ver detalles";

--- a/Sources/DeclarationAccessibility/Ressources/nl.lproj/Localizable.strings
+++ b/Sources/DeclarationAccessibility/Ressources/nl.lproj/Localizable.strings
@@ -1,0 +1,16 @@
+// Software Name: accessibility-statement-lib-ios
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: Apache-2.0
+//
+// This software is distributed under the Apache 2.0 license,
+// the text of which is available at https://opensource.org/license/apache-2-0
+// or see the "LICENSE" file for more details.
+
+"declaration_title" = "Informatie";
+"average_title_label" = "conform met @%";
+"result_declaration_subtitle" = "Deze app is conform met @% aan de WCAG-criteria";
+"date_title" = "Datum van de audit";
+"identity_title" = "Identiteit aangever";
+"referential_title" = "Toegepaste standaard";
+"technology_title" = "Technische specificaties";
+"detail_button" = "Details bekijken";

--- a/Sources/DeclarationAccessibility/Ressources/pl.lproj/Localizable.strings
+++ b/Sources/DeclarationAccessibility/Ressources/pl.lproj/Localizable.strings
@@ -1,0 +1,16 @@
+// Software Name: accessibility-statement-lib-ios
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: Apache-2.0
+//
+// This software is distributed under the Apache 2.0 license,
+// the text of which is available at https://opensource.org/license/apache-2-0
+// or see the "LICENSE" file for more details.
+
+"declaration_title" = "Informacje";
+"average_title_label" = "zgodność z @%";
+"result_declaration_subtitle" = "Ta aplikacja jest zgodna z wytycznymi WCAG @%";
+"date_title" = "Data audytu";
+"identity_title" = "Tożsamość zgłaszającego";
+"referential_title" = "Zastosowany standard";
+"technology_title" = "Specyfikacja techniczna";
+"detail_button" = "Zobacz szczegóły";

--- a/Sources/DeclarationAccessibility/Ressources/ro.lproj/Localizable.strings
+++ b/Sources/DeclarationAccessibility/Ressources/ro.lproj/Localizable.strings
@@ -1,0 +1,16 @@
+// Software Name: accessibility-statement-lib-ios
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: Apache-2.0
+//
+// This software is distributed under the Apache 2.0 license,
+// the text of which is available at https://opensource.org/license/apache-2-0
+// or see the "LICENSE" file for more details.
+
+"declaration_title" = "Informații";
+"average_title_label" = "compatibil @%";
+"result_declaration_subtitle" = "Aceasta aplicație este @% ompatibilă cu criteriile WCAG";
+"date_title" = "Data auditului";
+"identity_title" = "Identitate declarant";
+"referential_title" = "Standard aplicat";
+"technology_title" = "Specificații tehnice";
+"detail_button" = "Vezi detaliile";

--- a/Sources/DeclarationAccessibility/Ressources/ru.lproj/Localizable.strings
+++ b/Sources/DeclarationAccessibility/Ressources/ru.lproj/Localizable.strings
@@ -1,0 +1,16 @@
+// Software Name: accessibility-statement-lib-ios
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: Apache-2.0
+//
+// This software is distributed under the Apache 2.0 license,
+// the text of which is available at https://opensource.org/license/apache-2-0
+// or see the "LICENSE" file for more details.
+
+"declaration_title" = "Специальные";
+"average_title_label" = "соответствует @%";
+"result_declaration_subtitle" = "Приложение на @% соответствует критериям WCAG";
+"date_title" = "Дата проверки";
+"identity_title" = "Личность заявителя";
+"referential_title" = "Применяемый стандарт";
+"technology_title" = "Технические характеристики";
+"detail_button" = "Подробнее";

--- a/Sources/DeclarationAccessibility/Ressources/sk.lproj/Localizable.strings
+++ b/Sources/DeclarationAccessibility/Ressources/sk.lproj/Localizable.strings
@@ -1,0 +1,16 @@
+// Software Name: accessibility-statement-lib-ios
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: Apache-2.0
+//
+// This software is distributed under the Apache 2.0 license,
+// the text of which is available at https://opensource.org/license/apache-2-0
+// or see the "LICENSE" file for more details.
+
+"declaration_title" = "Informácie";
+"average_title_label" = "spĺňa @%";
+"result_declaration_subtitle" = "Táto aplikácia spĺňa @% kritériá WCAG";
+"date_title" = "Dátum auditu";
+"identity_title" = "Totožnost vyhlasovatela";
+"referential_title" = "Použité normy";
+"technology_title" = "Technické špecifikácie";
+"detail_button" = "Zobraziť podrobné údaje";

--- a/Sources/DeclarationAccessibility/View/CircularProgressView.swift
+++ b/Sources/DeclarationAccessibility/View/CircularProgressView.swift
@@ -81,8 +81,9 @@ struct CircularProgressView_Previews: PreviewProvider {
             statement: Statement(
                 conformityAverage: 0.75,
                 conformityAverageDisplay: "75"),
-            theme: OrangeTheme())
+            theme: WireframeTheme())
             .environment(\.locale, .init(identifier: "fr"))
+            .wireframePreview()
     }
 }
 

--- a/Sources/DeclarationAccessibility/View/InformationView.swift
+++ b/Sources/DeclarationAccessibility/View/InformationView.swift
@@ -121,8 +121,9 @@ struct InformationView_Previews: PreviewProvider {
             detailUrl: "https://example.com",
             identityAddress: "Test Identity Address",
             identityName: "Test Identity Name"),
-        theme: OrangeTheme())
+        theme: WireframeTheme())
             .environment(\.locale, .init(identifier: "fr"))
+            .wireframePreview()
     }
 }
 

--- a/Sources/DeclarationAccessibility/View/InformationView.swift
+++ b/Sources/DeclarationAccessibility/View/InformationView.swift
@@ -103,7 +103,10 @@ private struct WebViewPage: View {
     // swiftlint:disable force_unwrapping
     var body: some View {
         StatementWebView(from: URL(string: url)!) // FIXME: Manage this error case
-            .navigationTitle("Details") // FIXME: Hard-coded not localized wording
+            .navigationTitle(NSLocalizedString( // FIXME: Change API
+                "declaration_title",
+                bundle: .module,
+                comment: ""))
     }
     // swiftlint:enable force_unwrapping
 }

--- a/Sources/DeclarationAccessibility/View/StatementView.swift
+++ b/Sources/DeclarationAccessibility/View/StatementView.swift
@@ -162,10 +162,10 @@ public struct StatementView: View {
 
     #if DEBUG
     /// Initializer dedicated to the Xcode Preview
-    init(_ statement: Statement, theme: Theme) {
+    init(_ statement: Statement, theme: OUDSTheme) {
         self.statement = statement
-        self.theme = theme
-        oudsTheme = nil
+        self.theme = nil
+        oudsTheme = theme
     }
     #endif
 
@@ -221,6 +221,7 @@ extension Theme {
             technologies: "Swift, SwiftUI",
             identityAddress: Constants.Orange.identityAddress,
             identityName: Constants.Orange.identityName),
-        theme: .orange)
+        theme: WireframeTheme())
+        .wireframePreview()
 }
 #endif


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->
#46 
#53 

### Description

<!-- Describe your changes in detail -->
- Add support for more locales (ca, es, nl, pl, ro, ru, sk)
- Remove hard-coded title for webview and replace it by suitable localizable

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
- Improve l10n

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)
- New feature (non-breaking change which adds functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/accessibility-statement-lib-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows [accessibility good practices](https://a11y-guidelines.orange.com/)

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ccessibility-statement-lib-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/accessibility-statement-lib-ios/blob/develop/.github/CODEOWNERS)
- [x] Design, a11Y, Q/A review have been done
- [x] Documentation has been updated if relevant
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
