### PR TITLE
[#54] Vocalization of date of audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- When use of Voice Over, moth of audit date is shortened and not well vocalizeed (Orange-OpenSource/accessibility-statement-lib-ios#54)
 - Hard-coded "Details" word instead of localized resource in webview title (Orange-OpenSource/accessibility-statement-lib-ios#53)
 
 ## [2.0.0](https://github.com/Orange-OpenSource/accessibility-statement-lib-ios/compare/1.3.0...2.0.0) - 2026-01-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- When use of Voice Over, moth of audit date is shortened and not well vocalizeed (Orange-OpenSource/accessibility-statement-lib-ios#54)
+- When using VoiceOver, the audit date month was abbreviated and not vocalized correctly (Orange-OpenSource/accessibility-statement-lib-ios#54)
 - Hard-coded "Details" word instead of localized resource in webview title (Orange-OpenSource/accessibility-statement-lib-ios#53)
 
 ## [2.0.0](https://github.com/Orange-OpenSource/accessibility-statement-lib-ios/compare/1.3.0...2.0.0) - 2026-01-22

--- a/Sources/DeclarationAccessibility/Model/Statement.swift
+++ b/Sources/DeclarationAccessibility/Model/Statement.swift
@@ -11,12 +11,17 @@ import Foundation
 /// Defines what an accessibility statement or declaration must be.
 struct Statement {
 
+    // MARK: - Type alias
+
+    /// Modelizes a date of audit to display in the statement and to vocalize with Voice Over
+    typealias AuditDate = (toDisplay: String, toVocalize: String)
+
     // MARK: - Properties
 
     var title: String
     var lang: String
     var status: String
-    var auditDate: String
+    var auditDate: AuditDate?
     var conformity: String
     var conformityAverage: CGFloat
     var conformityAverageDisplay: String
@@ -35,7 +40,7 @@ struct Statement {
         title: String = "",
         lang: String = "",
         status: String = "",
-        auditDate: String = "",
+        auditDate: AuditDate? = nil,
         conformity: String = "",
         conformityAverage: CGFloat = 0.0,
         conformityAverageDisplay: String = "",

--- a/Sources/DeclarationAccessibility/Model/StatementDataParser.swift
+++ b/Sources/DeclarationAccessibility/Model/StatementDataParser.swift
@@ -51,6 +51,7 @@ final class StatementDataParser: NSObject, XMLParserDelegate {
         }
     }
 
+    // TODO: Refactor the parsing
     func parser(_: XMLParser, foundCharacters string: String) {
         let data = string.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
 
@@ -113,7 +114,7 @@ final class StatementDataParser: NSObject, XMLParserDelegate {
             let languageAsNSString = language as NSString
             languageString = (languageAsNSString as String)
         } else {
-            languageString = "en_EN"
+            languageString = "en_US"
         }
 
         // TODO: Use Cache to store DateFormatter and results to prevent costly computing of such values

--- a/Sources/DeclarationAccessibility/Model/StatementDataParser.swift
+++ b/Sources/DeclarationAccessibility/Model/StatementDataParser.swift
@@ -59,8 +59,7 @@ final class StatementDataParser: NSObject, XMLParserDelegate {
             case "title_app":
                 statement.title += " \(data)"
             case "audit_date":
-                statement.auditDate += " \(data)"
-                statement.auditDate = dateToFrench(inputDate: statement.auditDate)
+                statement.auditDate = localizedDates(inputDate: " \(data)")
             case "conformity":
                 if foundTotalResult {
                     if let conformity = Float(string) {
@@ -105,7 +104,7 @@ final class StatementDataParser: NSObject, XMLParserDelegate {
         NotificationCenter.default.post(name: Notification.Name("DeclarationDataDidUpdate"), object: nil, userInfo: ["declarationData": statement])
     }
 
-    private func dateToFrench(inputDate: String) -> String {
+    private func localizedDates(inputDate: String) -> (toDisplay: String, toVocalize: String)? {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd"
 
@@ -114,13 +113,21 @@ final class StatementDataParser: NSObject, XMLParserDelegate {
             let languageAsNSString = language as NSString
             languageString = (languageAsNSString as String)
         } else {
-            languageString = "fr_FR"
+            languageString = "en_EN"
         }
 
-        guard let date = dateFormatter.date(from: inputDate) else { return "" }
+        // TODO: Use Cache to store DateFormatter and results to prevent costly computing of such values
+        guard let date = dateFormatter.date(from: inputDate) else { return nil }
         dateFormatter.locale = Locale(identifier: languageString)
-        dateFormatter.dateFormat = DateFormatter.dateFormat(fromTemplate: "dd-MMM-yyyy", options: 0, locale: dateFormatter.locale)
+
+        let dateFormatForDisplay = DateFormatter.dateFormat(fromTemplate: "dd-MMM-yyyy", options: 0, locale: dateFormatter.locale)
+        dateFormatter.dateFormat = dateFormatForDisplay
         let localDate = dateFormatter.string(from: date)
-        return localDate
+
+        let dateFormatForVocalization = DateFormatter.dateFormat(fromTemplate: "dd-MMMM-yyyy", options: 0, locale: dateFormatter.locale)
+        dateFormatter.dateFormat = dateFormatForVocalization
+        let toVocalize = dateFormatter.string(from: date)
+
+        return (toDisplay: localDate, toVocalize: toVocalize)
     }
 }

--- a/Sources/DeclarationAccessibility/View/InformationView.swift
+++ b/Sources/DeclarationAccessibility/View/InformationView.swift
@@ -23,8 +23,11 @@ struct InformationView: View {
     var body: some View {
         ScrollView {
             VStack(spacing: -10) {
-                GroupView(title: "date_title", subTitle: statement.auditDate)
-                    .accessibilityElement(children: .combine)
+                if let auditDate = statement.auditDate {
+                    GroupView(title: "date_title", subTitle: auditDate.toDisplay)
+                        .accessibilityElement(children: .combine)
+                        .accessibilityLabel(auditDate.toVocalize)
+                }
                 GroupView(title: "identity_title", subTitle: statement.identityName, text: statement.identityAddress)
                     .accessibilityElement(children: .combine)
                 GroupView(title: "referential_title", subTitle: statement.referentialName)
@@ -116,7 +119,7 @@ private struct WebViewPage: View {
 struct InformationView_Previews: PreviewProvider {
     static var previews: some View {
         InformationView(statement: Statement(
-            auditDate: "Test Audit Date",
+            auditDate: (toDisplay: "Test Audit Date", toVocalize: ""),
             referentialName: "Test Referential Name",
             referentialVersion: "Test Referential Version",
             referentialLevel: "Test Referential Level",

--- a/Sources/DeclarationAccessibility/View/InformationView.swift
+++ b/Sources/DeclarationAccessibility/View/InformationView.swift
@@ -26,7 +26,9 @@ struct InformationView: View {
                 if let auditDate = statement.auditDate {
                     GroupView(title: "date_title", subTitle: auditDate.toDisplay)
                         .accessibilityElement(children: .combine)
-                        .accessibilityLabel(auditDate.toVocalize)
+                        .accessibilityValue(auditDate.toVocalize.isEmpty
+                            ? auditDate.toDisplay
+                            : auditDate.toVocalize)
                 }
                 GroupView(title: "identity_title", subTitle: statement.identityName, text: statement.identityAddress)
                     .accessibilityElement(children: .combine)

--- a/Sources/DeclarationAccessibility/View/StatementView.swift
+++ b/Sources/DeclarationAccessibility/View/StatementView.swift
@@ -214,7 +214,7 @@ extension Theme {
         Statement(
             title: "Accessibility Statement",
             lang: "EN",
-            auditDate: "22 janv. 2026",
+            auditDate: (toDisplay: "22 janv. 2026", toVocalize: ""),
             conformityAverage: 0.75,
             conformityAverageDisplay: "75",
             referentialName: "WCAG 2.2 AA",

--- a/Tests/DeclarationAccessibilityTests/StatementDataParserTests.swift
+++ b/Tests/DeclarationAccessibilityTests/StatementDataParserTests.swift
@@ -29,10 +29,10 @@ struct StatementDataParserTests {
         #expect(statement.status.isEmpty)
     }
 
-    @Test("By default a Statement has empty audit date")
-    func statementDefaultHasEmptyAuditDate() {
+    @Test("By default a Statement does not have audit date")
+    func statementDefaultHasNilAuditDate() {
         let statement = Statement()
-        #expect(statement.auditDate.isEmpty)
+        #expect(statement.auditDate == nil)
     }
 
     @Test("By default a Statement has empty audit conformity")

--- a/Tests/DeclarationAccessibilityTests/StatementTests.swift
+++ b/Tests/DeclarationAccessibilityTests/StatementTests.swift
@@ -24,7 +24,7 @@ struct StatementTests {
         #expect(statement.title.isEmpty)
         #expect(statement.lang.isEmpty)
         #expect(statement.status.isEmpty)
-        #expect(statement.auditDate.isEmpty)
+        #expect(statement.auditDate == nil)
         #expect(statement.conformityAverage == 0.0)
         #expect(statement.conformityAverageDisplay.isEmpty)
         #expect(statement.referentialName.isEmpty)


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->
#54

### Description

<!-- Describe your changes in detail -->
Use a plain-text-month format for Voice Oiver vocalization to improve a11y

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Improve a11y and vocalization of date witthout shortened version of month

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/accessibility-statement-lib-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows [accessibility good practices](https://a11y-guidelines.orange.com/)

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ccessibility-statement-lib-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [ ] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/accessibility-statement-lib-ios/blob/develop/.github/CODEOWNERS)
- [x] Design, a11Y, Q/A review have been done
- [x] Documentation has been updated if relevant
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
