### PR TITLE
[#65] Use `link` accessibility trait for more-details-button instead of `button` (version 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased](https://github.com/Orange-OpenSource/accessibility-statement-lib-ios/compare/2.0.0...develop)
+
+### Fixed
+
+- The "more details" component should be a link instead of a button (Orange-OpenSource/accessibility-statement-lib-ios#65)
+
 ## [2.1.2](https://github.com/Orange-OpenSource/accessibility-statement-lib-ios/compare/2.0.0...2.1.2) - 2026-01-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased](https://github.com/Orange-OpenSource/accessibility-statement-lib-ios/compare/2.2.0...develop)
+
+### Fixed
+
+- The "more details" component should be a link instead of a button (Orange-OpenSource/accessibility-statement-lib-ios#65)
+
 ## [2.2.0](https://github.com/Orange-OpenSource/accessibility-statement-lib-ios/compare/2.1.2...2.2.0) - 2026-05-07
 
 ### Added

--- a/Sources/DeclarationAccessibility/View/InformationView.swift
+++ b/Sources/DeclarationAccessibility/View/InformationView.swift
@@ -53,6 +53,8 @@ struct InformationView: View {
                     {
                         showWebView = true
                     }
+                    .accessibilityRemoveTraits(.isButton)
+                    .accessibilityAddTraits(.isLink)
                 } else {
                     OUDSButton(text: NSLocalizedString("detail_button", bundle: .module, comment: ""),
                                appearance: .strong)
@@ -61,6 +63,8 @@ struct InformationView: View {
                             UIApplication.shared.open(url)
                         }
                     }
+                    .accessibilityRemoveTraits(.isButton)
+                    .accessibilityAddTraits(.isLink)
                 }
             }
         }


### PR DESCRIPTION
### Related issues

<!-- Please link any related issues here. -->
#65

### Description

<!-- Describe your changes in detail -->
Update accessibility traits for v2 to expose detailed button as link with Voice Over

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Improve a11y and be more compliant with use of web view and web browsers to display detailed page

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Refactoring (non-breaking change)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/accessibility-statement-lib-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows [accessibility good practices](https://a11y-guidelines.orange.com/)

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ccessibility-statement-lib-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [x] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/accessibility-statement-lib-ios/blob/develop/.github/CODEOWNERS)
- [ ] Design, a11Y, Q/A review have been done
- [x] Documentation has been updated if relevant
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
