### PR TITLE
Use OUDS version 1.2.x to apply new naming of `Orange Business Tools` theme (`OrangeCompact`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
-
 # Accessibility Statement Lib iOS
 
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased](https://github.com/Orange-OpenSource/accessibility-statement-lib-ios/compare/2.1.2..develop)
+
+### Changed
+
+- Update OUDS version
 
 ## [2.1.2](https://github.com/Orange-OpenSource/accessibility-statement-lib-ios/compare/2.0.0...2.1.2) - 2026-01-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/Orange-OpenSource/accessibility-statement-lib-ios/compare/2.1.2..develop)
 
-### Changed
+### Added
 
-- Update OUDS version
+- `.orangeCompact` configuration for `Theme` with new OUDS version (rename of `Orange Business Tools` to `Orange Compact`)
 
 ## [2.1.2](https://github.com/Orange-OpenSource/accessibility-statement-lib-ios/compare/2.0.0...2.1.2) - 2026-01-27
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Orange-OpenSource/ouds-ios",
       "state" : {
-        "revision" : "458e8ed4f1a78ac0305b49369bb7ccc717a10045",
-        "version" : "1.1.0"
+        "branch" : "develop",
+        "revision" : "77463e0dde76731438ca819aaa043517688ef1f6"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
         .package(url: "https://github.com/swiftlang/swift-docc-plugin", exact: "1.4.5"),
-        .package(url: "https://github.com/Orange-OpenSource/ouds-ios", exact: "1.1.0"),
+        .package(url: "https://github.com/Orange-OpenSource/ouds-ios", branch: "develop"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/DeclarationAccessibility/Utils/Theme.swift
+++ b/Sources/DeclarationAccessibility/Utils/Theme.swift
@@ -17,14 +17,17 @@ import SwiftUI
 public enum Theme: String {
 
     /// For the Orange Innovation Cup
-    @available(*, deprecated, message: "Use wireframe theme instead")
+    @available(*, deprecated, message: "Use .wireframe instead")
     case innovation
 
     /// For the Orange brand products
     case orange
 
-    /// For the Orange brand products with contraintes of spaces and sizes
+    @available(*, deprecated, message: "Use .orangeCompact instead")
     case orangeBusinessTools
+
+    /// For the Orange brand products with constraints of spaces and sizes
+    case orangeCompact
 
     /// For the Sosh brand products
     case sosh

--- a/Sources/DeclarationAccessibility/View/StatementView.swift
+++ b/Sources/DeclarationAccessibility/View/StatementView.swift
@@ -199,8 +199,8 @@ extension Theme {
             return WireframeTheme()
         case .orange:
             return OrangeTheme()
-        case .orangeBusinessTools:
-            return OrangeBusinessToolsTheme()
+        case .orangeBusinessTools, .orangeCompact:
+            return OrangeCompactTheme()
         case .sosh:
             return SoshTheme()
         }


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Description

<!-- Describe your changes in detail -->
- New version of OUDS will  contain a change: `Orange Business Tool` theme will be renamed to `Orange Compact`
- The v2 of the lib should use last version of OUDS with this renaming

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
- Avoid conflicts in apps using both OUDS and the statement lib

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Refactoring (non-breaking change)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/accessibility-statement-lib-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA)My change follows [accessibility good practices](https://a11y-guidelines.orange.com/)

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ccessibility-statement-lib-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/accessibility-statement-lib-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design, a11Y, Q/A review have been done
- [x] Documentation has been updated if relevant
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
